### PR TITLE
Add Rubrics category to sidebar tree view (Issue #1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,12 +69,12 @@
       {
         "view": "canvasAuthorCourses",
         "contents": "Welcome to Canvas Author!\n\nCreate courses offline or connect to Canvas.\n\n[Create Local Course](command:canvas-author.createLocalCourse)\n[Clone from Git](command:canvas-author.cloneFromRemote)\n\n---\n\nTo sync with Canvas LMS:\n[Connect to Canvas](command:canvas-author.showOnboarding)",
-        "when": "!canvas-author.hasToken"
+        "when": "!canvas-author.hasCourses && !canvas-author.hasToken"
       },
       {
         "view": "canvasAuthorCourses",
         "contents": "No courses yet.\n\n[Create Local Course](command:canvas-author.createLocalCourse)\n[Import from Canvas](command:canvas-author.addCourse)\n[Clone from Git](command:canvas-author.cloneFromRemote)",
-        "when": "canvas-author.hasToken"
+        "when": "!canvas-author.hasCourses && canvas-author.hasToken"
       }
     ],
     "menus": {
@@ -155,6 +155,16 @@
           "command": "canvas-author.createPage",
           "when": "view == canvasAuthorCourses && viewItem == category",
           "group": "create@1"
+        },
+        {
+          "command": "canvas-author.pullRubrics",
+          "when": "view == canvasAuthorCourses && viewItem == rubric",
+          "group": "sync@1"
+        },
+        {
+          "command": "canvas-author.pushRubrics",
+          "when": "view == canvasAuthorCourses && viewItem == rubric",
+          "group": "sync@2"
         }
       ]
     },

--- a/src/courseTreeProvider.ts
+++ b/src/courseTreeProvider.ts
@@ -1,0 +1,787 @@
+import * as vscode from 'vscode'
+import * as path from 'path'
+import * as fs from 'fs'
+import * as os from 'os'
+import { CanvasMcpClient } from './mcpClient'
+
+// Sync status icons
+const ICONS = {
+  synced: new vscode.ThemeIcon('check', new vscode.ThemeColor('testing.iconPassed')),
+  modified: new vscode.ThemeIcon('warning', new vscode.ThemeColor('editorWarning.foreground')),
+  localOnly: new vscode.ThemeIcon('cloud-upload', new vscode.ThemeColor('gitDecoration.untrackedResourceForeground')),
+  canvasOnly: new vscode.ThemeIcon('cloud-download', new vscode.ThemeColor('gitDecoration.deletedResourceForeground')),
+  course: new vscode.ThemeIcon('book'),
+  pages: new vscode.ThemeIcon('file-text'),
+  quizzes: new vscode.ThemeIcon('tasklist'),
+  assignments: new vscode.ThemeIcon('note'),
+  modules: new vscode.ThemeIcon('list-tree'),
+  rubrics: new vscode.ThemeIcon('checklist'),
+  settings: new vscode.ThemeIcon('gear'),
+  page: new vscode.ThemeIcon('markdown'),
+  quiz: new vscode.ThemeIcon('question'),
+  assignment: new vscode.ThemeIcon('edit'),
+  module: new vscode.ThemeIcon('folder'),
+  rubric: new vscode.ThemeIcon('list-ordered'),
+  addCourse: new vscode.ThemeIcon('add')
+}
+
+export type SyncStatus = 'synced' | 'modified' | 'localOnly' | 'canvasOnly' | 'unknown'
+
+export interface CourseInfo {
+  id: string
+  name: string
+  courseCode: string
+  localPath: string
+  remoteUrl?: string
+}
+
+export interface CourseRegistry {
+  courses: CourseInfo[]
+  defaultStoragePath: string
+}
+
+export class CourseTreeItem extends vscode.TreeItem {
+  public externalUrl?: string  // For external URL module items
+
+  constructor(
+    public readonly label: string,
+    public readonly collapsibleState: vscode.TreeItemCollapsibleState,
+    public readonly itemType: 'course' | 'category' | 'page' | 'quiz' | 'assignment' | 'module' | 'moduleItem' | 'rubric' | 'settings' | 'addCourse',
+    public readonly courseInfo?: CourseInfo,
+    public readonly resourcePath?: string,
+    public readonly syncStatus?: SyncStatus,
+    public readonly moduleName?: string  // For module items to know which module they belong to
+  ) {
+    super(label, collapsibleState)
+    this.contextValue = itemType
+    this.setIcon()
+    this.setTooltip()
+    this.setCommand()
+  }
+
+  private setIcon() {
+    switch (this.itemType) {
+      case 'course':
+        this.iconPath = ICONS.course
+        break
+      case 'category':
+        if (this.label === 'Pages') this.iconPath = ICONS.pages
+        else if (this.label === 'Assignments') this.iconPath = ICONS.assignments
+        else if (this.label === 'Quizzes') this.iconPath = ICONS.quizzes
+        else if (this.label === 'Modules') this.iconPath = ICONS.modules
+        else if (this.label === 'Rubrics') this.iconPath = ICONS.rubrics
+        else if (this.label === 'Settings') this.iconPath = ICONS.settings
+        break
+      case 'page':
+        this.iconPath = this.getSyncIcon() || ICONS.page
+        break
+      case 'assignment':
+        this.iconPath = this.getSyncIcon() || ICONS.assignment
+        break
+      case 'quiz':
+        this.iconPath = this.getSyncIcon() || ICONS.quiz
+        break
+      case 'rubric':
+        this.iconPath = this.getSyncIcon() || ICONS.rubric
+        break
+      case 'module':
+        this.iconPath = ICONS.module
+        break
+      case 'moduleItem':
+        // Module items get icons based on their type (stored in description)
+        if (this.description === 'page') this.iconPath = ICONS.page
+        else if (this.description === 'assignment') this.iconPath = ICONS.assignment
+        else if (this.description === 'quiz') this.iconPath = ICONS.quiz
+        else if (this.description === 'external_url') this.iconPath = new vscode.ThemeIcon('link-external')
+        else if (this.description === 'subheader') this.iconPath = new vscode.ThemeIcon('symbol-namespace')
+        else this.iconPath = new vscode.ThemeIcon('circle-outline')
+        break
+      case 'settings':
+        this.iconPath = ICONS.settings
+        break
+      case 'addCourse':
+        this.iconPath = ICONS.addCourse
+        break
+    }
+  }
+
+  private getSyncIcon(): vscode.ThemeIcon | undefined {
+    switch (this.syncStatus) {
+      case 'synced': return ICONS.synced
+      case 'modified': return ICONS.modified
+      case 'localOnly': return ICONS.localOnly
+      case 'canvasOnly': return ICONS.canvasOnly
+      default: return undefined
+    }
+  }
+
+  private setTooltip() {
+    if (this.syncStatus) {
+      const statusText: Record<SyncStatus, string> = {
+        synced: 'Synced with Canvas',
+        modified: 'Modified locally',
+        localOnly: 'Local only - not in Canvas',
+        canvasOnly: 'Canvas only - not downloaded',
+        unknown: 'Sync status unknown'
+      }
+      this.tooltip = statusText[this.syncStatus] || this.label
+    }
+    if (this.resourcePath) {
+      this.tooltip = `${this.tooltip || this.label}\n${this.resourcePath}`
+    }
+  }
+
+  private setCommand() {
+    if (this.resourcePath && (this.itemType === 'page' || this.itemType === 'quiz' || this.itemType === 'assignment' || this.itemType === 'rubric' || this.itemType === 'settings' || this.itemType === 'moduleItem')) {
+      this.command = {
+        command: 'vscode.open',
+        title: 'Open File',
+        arguments: [vscode.Uri.file(this.resourcePath)]
+      }
+    } else if (this.itemType === 'moduleItem' && this.externalUrl) {
+      // Open external URLs in simple browser
+      this.command = {
+        command: 'simpleBrowser.api.open',
+        title: 'Open URL',
+        arguments: [this.externalUrl, { viewColumn: vscode.ViewColumn.Beside }]
+      }
+    } else if (this.itemType === 'addCourse') {
+      this.command = {
+        command: 'canvas-author.addCourse',
+        title: 'Add Course'
+      }
+    }
+  }
+}
+
+export class CourseTreeProvider implements vscode.TreeDataProvider<CourseTreeItem> {
+  private _onDidChangeTreeData = new vscode.EventEmitter<CourseTreeItem | undefined>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  private registry: CourseRegistry
+  private registryPath: string
+  private fileWatchers: Map<string, vscode.FileSystemWatcher> = new Map();
+  private mcpClient: CanvasMcpClient | undefined
+  private syncedCategories: Set<string> = new Set(); // Track what's been synced this session
+
+  constructor(private context: vscode.ExtensionContext) {
+    this.registryPath = path.join(this.getStoragePath(), 'registry.json')
+    this.registry = this.loadRegistry()
+    this.setupFileWatchers()
+    // Set hasCourses context immediately from cached registry
+    this.updateHasCoursesContext()
+  }
+
+  private updateHasCoursesContext() {
+    vscode.commands.executeCommand('setContext', 'canvas-author.hasCourses', this.registry.courses.length > 0)
+  }
+
+  setMcpClient(client: CanvasMcpClient | undefined) {
+    this.mcpClient = client
+  }
+
+  getStoragePath(): string {
+    return path.join(os.homedir(), '.canvas-author')
+  }
+
+  private loadRegistry(): CourseRegistry {
+    const storagePath = this.getStoragePath()
+
+    // Ensure storage directory exists
+    if (!fs.existsSync(storagePath)) {
+      fs.mkdirSync(storagePath, { recursive: true })
+    }
+
+    if (fs.existsSync(this.registryPath)) {
+      try {
+        const data = fs.readFileSync(this.registryPath, 'utf8')
+        return JSON.parse(data)
+      } catch (e) {
+        console.error('Failed to load registry:', e)
+      }
+    }
+
+    return {
+      courses: [],
+      defaultStoragePath: path.join(storagePath, 'courses')
+    }
+  }
+
+  saveRegistry() {
+    try {
+      fs.writeFileSync(this.registryPath, JSON.stringify(this.registry, null, 2))
+    } catch (e) {
+      console.error('Failed to save registry:', e)
+    }
+  }
+
+  private setupFileWatchers() {
+    // Watch for changes in registered course directories
+    for (const course of this.registry.courses) {
+      this.watchCourse(course.localPath)
+    }
+  }
+
+  private watchCourse(coursePath: string) {
+    if (this.fileWatchers.has(coursePath)) {
+      return
+    }
+
+    const pattern = new vscode.RelativePattern(coursePath, '**/*.{md,yaml,json}')
+    const watcher = vscode.workspace.createFileSystemWatcher(pattern)
+
+    watcher.onDidChange(() => this.refresh())
+    watcher.onDidCreate(() => this.refresh())
+    watcher.onDidDelete(() => this.refresh())
+
+    this.fileWatchers.set(coursePath, watcher)
+  }
+
+  refresh(): void {
+    this.updateHasCoursesContext()
+    this._onDidChangeTreeData.fire(undefined)
+  }
+
+  getTreeItem(element: CourseTreeItem): vscode.TreeItem {
+    return element
+  }
+
+  async getChildren(element?: CourseTreeItem): Promise<CourseTreeItem[]> {
+    if (!element) {
+      // Root level: show courses and "Add Course" item
+      return this.getCourses()
+    }
+
+    if (element.itemType === 'course' && element.courseInfo) {
+      // Course level: show categories
+      return this.getCourseCategories(element.courseInfo)
+    }
+
+    if (element.itemType === 'category' && element.courseInfo) {
+      // Category level: show items
+      return this.getCategoryItems(element.label, element.courseInfo)
+    }
+
+    if (element.itemType === 'module' && element.courseInfo) {
+      // Module level: show module items
+      return this.getModuleItemChildren(element.label, element.courseInfo)
+    }
+
+    return []
+  }
+
+  private getCourses(): CourseTreeItem[] {
+    const items: CourseTreeItem[] = []
+
+    // Add registered courses
+    for (const course of this.registry.courses) {
+      items.push(new CourseTreeItem(
+        course.name,
+        vscode.TreeItemCollapsibleState.Collapsed,
+        'course',
+        course
+      ))
+    }
+
+    return items
+  }
+
+  private getCourseCategories(course: CourseInfo): CourseTreeItem[] {
+    return [
+      new CourseTreeItem('Pages', vscode.TreeItemCollapsibleState.Collapsed, 'category', course),
+      new CourseTreeItem('Assignments', vscode.TreeItemCollapsibleState.Collapsed, 'category', course),
+      new CourseTreeItem('Quizzes', vscode.TreeItemCollapsibleState.Collapsed, 'category', course),
+      new CourseTreeItem('Modules', vscode.TreeItemCollapsibleState.Collapsed, 'category', course),
+      new CourseTreeItem('Rubrics', vscode.TreeItemCollapsibleState.Collapsed, 'category', course),
+      new CourseTreeItem('Settings', vscode.TreeItemCollapsibleState.None, 'settings', course,
+        path.join(course.localPath, 'course.yaml'))
+    ]
+  }
+
+  private async getCategoryItems(category: string, course: CourseInfo): Promise<CourseTreeItem[]> {
+    let items: CourseTreeItem[] = []
+    const coursePath = course.localPath
+    const syncKey = `${course.id}:${category}`
+
+    switch (category) {
+      case 'Pages':
+        items = await this.getPageItems(coursePath, course)
+        // Auto-sync if empty and not already synced this session
+        if (items.length === 0 && !this.syncedCategories.has(syncKey)) {
+          await this.autoSyncCategory('pull_pages', course.id, coursePath, 'output_dir')
+          this.syncedCategories.add(syncKey)
+          items = await this.getPageItems(coursePath, course)
+        }
+        break
+      case 'Assignments':
+        items = await this.getAssignmentItems(coursePath, course)
+        if (items.length === 0 && !this.syncedCategories.has(syncKey)) {
+          await this.autoSyncCategory('pull_assignments', course.id, coursePath, 'output_dir')
+          this.syncedCategories.add(syncKey)
+          items = await this.getAssignmentItems(coursePath, course)
+        }
+        break
+      case 'Quizzes':
+        items = await this.getQuizItems(coursePath, course)
+        if (items.length === 0 && !this.syncedCategories.has(syncKey)) {
+          await this.autoSyncCategory('pull_quizzes', course.id, coursePath, 'output_dir')
+          this.syncedCategories.add(syncKey)
+          items = await this.getQuizItems(coursePath, course)
+        }
+        break
+      case 'Modules':
+        items = await this.getModuleItems(coursePath, course)
+        if (items.length === 0 && !this.syncedCategories.has(syncKey)) {
+          await this.autoSyncCategory('pull_modules', course.id, coursePath, 'output_dir')
+          this.syncedCategories.add(syncKey)
+          items = await this.getModuleItems(coursePath, course)
+        }
+        break
+      case 'Rubrics':
+        items = await this.getRubricItems(coursePath, course)
+        if (items.length === 0 && !this.syncedCategories.has(syncKey)) {
+          await this.autoSyncCategory('pull_rubrics', course.id, coursePath, 'output_dir')
+          this.syncedCategories.add(syncKey)
+          items = await this.getRubricItems(coursePath, course)
+        }
+        break
+    }
+
+    return items
+  }
+
+  private async autoSyncCategory(toolName: string, courseId: string, coursePath: string, dirParam: string): Promise<void> {
+    if (!this.mcpClient) {
+      console.log(`Auto-sync skipped for ${toolName}: no MCP client`)
+      return
+    }
+
+    console.log(`Auto-sync starting: ${toolName} with course_id=${courseId}, ${dirParam}=${coursePath}`)
+
+    try {
+      await vscode.window.withProgress({
+        location: vscode.ProgressLocation.Notification,
+        title: `Syncing ${toolName.replace('pull_', '')} from Canvas...`,
+        cancellable: false
+      }, async () => {
+        const result = await this.mcpClient?.callTool(toolName, {
+          course_id: courseId,
+          [dirParam]: coursePath
+        })
+        console.log(`Auto-sync result for ${toolName}:`, JSON.stringify(result))
+        return result
+      })
+    } catch (error) {
+      console.error(`Auto-sync failed for ${toolName}: ${error}`)
+      vscode.window.showWarningMessage(`Failed to sync ${toolName.replace('pull_', '')}: ${error}`)
+    }
+  }
+
+  private async getPageItems(coursePath: string, course: CourseInfo): Promise<CourseTreeItem[]> {
+    const items: CourseTreeItem[] = []
+
+    // Find all .md files (excluding quizzes, assignments folders, and .quiz.md files)
+    const mdFiles = this.findFiles(coursePath, '.md', ['quizzes', 'assignments'])
+      .filter(f => !f.endsWith('.quiz.md'))
+
+    for (const file of mdFiles) {
+      const fileName = path.basename(file, '.md')
+      const status = await this.getFileSyncStatus(file, course)
+      items.push(new CourseTreeItem(
+        fileName,
+        vscode.TreeItemCollapsibleState.None,
+        'page',
+        course,
+        file,
+        status
+      ))
+    }
+
+    return items
+  }
+
+  private async getAssignmentItems(coursePath: string, course: CourseInfo): Promise<CourseTreeItem[]> {
+    const items: CourseTreeItem[] = []
+    const assignmentsPath = path.join(coursePath, 'assignments')
+
+    if (fs.existsSync(assignmentsPath)) {
+      const assignmentFiles = this.findFiles(assignmentsPath, '.md')
+
+      for (const file of assignmentFiles) {
+        const fileName = path.basename(file, '.md')
+        const status = await this.getFileSyncStatus(file, course)
+        items.push(new CourseTreeItem(
+          fileName,
+          vscode.TreeItemCollapsibleState.None,
+          'assignment',
+          course,
+          file,
+          status
+        ))
+      }
+    }
+
+    return items
+  }
+
+  private async getQuizItems(coursePath: string, course: CourseInfo): Promise<CourseTreeItem[]> {
+    const items: CourseTreeItem[] = []
+
+    // Look for .quiz.md files in the course root directory
+    const quizFiles = this.findFiles(coursePath, '.quiz.md', ['quizzes', 'assignments'])
+
+    for (const file of quizFiles) {
+      // Remove both .quiz.md extension
+      const fileName = path.basename(file, '.quiz.md')
+      const status = await this.getFileSyncStatus(file, course)
+      items.push(new CourseTreeItem(
+        fileName,
+        vscode.TreeItemCollapsibleState.None,
+        'quiz',
+        course,
+        file,
+        status
+      ))
+    }
+
+    return items
+  }
+
+  private async getModuleItems(coursePath: string, course: CourseInfo): Promise<CourseTreeItem[]> {
+    const items: CourseTreeItem[] = []
+    const modulesPath = path.join(coursePath, 'modules.yaml')
+
+    if (fs.existsSync(modulesPath)) {
+      try {
+        const content = fs.readFileSync(modulesPath, 'utf8')
+        const modules = this.parseModulesYaml(content)
+
+        for (const mod of modules) {
+          const hasItems = mod.items && mod.items.length > 0
+          items.push(new CourseTreeItem(
+            mod.name,
+            hasItems ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None,
+            'module',
+            course
+          ))
+        }
+      } catch (e) {
+        console.error('Failed to parse modules.yaml:', e)
+      }
+    }
+
+    return items
+  }
+
+  private async getRubricItems(coursePath: string, course: CourseInfo): Promise<CourseTreeItem[]> {
+    const items: CourseTreeItem[] = []
+    const rubricsPath = path.join(coursePath, 'rubrics')
+
+    if (!fs.existsSync(rubricsPath)) {
+      return items
+    }
+
+    // Find all .rubric.yaml files
+    const rubricFiles = this.findFiles(rubricsPath, '.rubric.yaml')
+
+    for (const file of rubricFiles) {
+      try {
+        const content = fs.readFileSync(file, 'utf8')
+        const rubricInfo = this.parseRubricYaml(content)
+        const status = await this.getRubricSyncStatus(file, content)
+
+        // Create label with assignment name and criteria count
+        let label = rubricInfo.assignmentName || path.basename(file, '.rubric.yaml')
+        if (rubricInfo.criteriaCount > 0) {
+          label += ` (${rubricInfo.criteriaCount} criteria)`
+        }
+
+        const item = new CourseTreeItem(
+          label,
+          vscode.TreeItemCollapsibleState.None,
+          'rubric',
+          course,
+          file,
+          status
+        )
+        // Store assignment name in description for display
+        if (rubricInfo.assignmentName) {
+          item.description = `${rubricInfo.pointsPossible || 0} pts`
+        }
+        items.push(item)
+      } catch (e) {
+        console.error(`Failed to parse rubric file ${file}:`, e)
+        // Still add the file even if parsing fails
+        items.push(new CourseTreeItem(
+          path.basename(file, '.rubric.yaml'),
+          vscode.TreeItemCollapsibleState.None,
+          'rubric',
+          course,
+          file,
+          'unknown'
+        ))
+      }
+    }
+
+    return items
+  }
+
+  private parseRubricYaml(content: string): { assignmentName?: string; criteriaCount: number; pointsPossible?: number; rubricId?: string } {
+    // Simple YAML parser for rubric structure
+    const result: { assignmentName?: string; criteriaCount: number; pointsPossible?: number; rubricId?: string } = {
+      criteriaCount: 0
+    }
+
+    // Extract assignment_name
+    const nameMatch = content.match(/^assignment_name:\s*['"]?(.+?)['"]?\s*$/m)
+    if (nameMatch) {
+      result.assignmentName = nameMatch[1]
+    }
+
+    // Extract rubric.id
+    const idMatch = content.match(/^\s+id:\s*['"]?(\d+)['"]?\s*$/m)
+    if (idMatch) {
+      result.rubricId = idMatch[1]
+    }
+
+    // Extract points_possible
+    const pointsMatch = content.match(/^\s+points_possible:\s*(\d+(?:\.\d+)?)\s*$/m)
+    if (pointsMatch) {
+      result.pointsPossible = parseFloat(pointsMatch[1])
+    }
+
+    // Count criteria (lines that start with "  - id:" or "  - description:" under criteria)
+    const criteriaMatches = content.match(/^\s{2,4}- (?:id:|description:)/gm)
+    if (criteriaMatches) {
+      result.criteriaCount = criteriaMatches.length
+    }
+
+    return result
+  }
+
+  private async getRubricSyncStatus(filePath: string, content: string): Promise<SyncStatus> {
+    // Check if file has rubric.id in content (indicates it's been synced)
+    if (content.includes('id:') && content.match(/^\s+id:\s*['"]?\d+['"]?\s*$/m)) {
+      // Has a rubric ID, so it's been synced
+      // TODO: Check if modified by comparing with Canvas
+      return 'synced'
+    }
+    return 'localOnly'
+  }
+
+  private getModuleItemChildren(moduleName: string, course: CourseInfo): CourseTreeItem[] {
+    const items: CourseTreeItem[] = []
+    const modulesPath = path.join(course.localPath, 'modules.yaml')
+
+    if (!fs.existsSync(modulesPath)) {
+      return items
+    }
+
+    try {
+      const content = fs.readFileSync(modulesPath, 'utf8')
+      const modules = this.parseModulesYaml(content)
+      const targetModule = modules.find(m => m.name === moduleName)
+
+      if (targetModule && targetModule.items) {
+        for (const item of targetModule.items) {
+          const label = item.title || item.page_url || item.url || 'Unknown'
+          const itemType = item.type || 'unknown'
+
+          // Find the local file path if it's a page
+          let resourcePath: string | undefined
+          if (itemType === 'page' && item.page_url) {
+            const pagePath = path.join(course.localPath, `${item.page_url}.md`)
+            if (fs.existsSync(pagePath)) {
+              resourcePath = pagePath
+            }
+          }
+
+          const treeItem = new CourseTreeItem(
+            label,
+            vscode.TreeItemCollapsibleState.None,
+            'moduleItem',
+            course,
+            resourcePath,
+            undefined,
+            moduleName
+          )
+          // Store item type in description for icon selection
+          treeItem.description = itemType
+          // Set external URL for link items
+          if (itemType === 'external_url' && item.url) {
+            treeItem.externalUrl = item.url
+          }
+          items.push(treeItem)
+        }
+      }
+    } catch (e) {
+      console.error('Failed to parse module items:', e)
+    }
+
+    return items
+  }
+
+  private parseModulesYaml(content: string): Array<{ name: string; published?: boolean; items?: Array<{ type?: string; title?: string; page_url?: string; url?: string; content_id?: string }> }> {
+    // Simple YAML parser for modules structure
+    const modules: Array<{ name: string; published?: boolean; items?: Array<{ type?: string; title?: string; page_url?: string; url?: string; content_id?: string }> }> = []
+
+    const lines = content.split('\n')
+    let currentModule: { name: string; published?: boolean; items?: Array<{ type?: string; title?: string; page_url?: string; url?: string; content_id?: string }> } | null = null
+    let currentItem: { type?: string; title?: string; page_url?: string; url?: string; content_id?: string } | null = null
+    let inItems = false
+
+    for (const line of lines) {
+      // Module start
+      if (line.match(/^- name: (.+)$/)) {
+        if (currentModule) {
+          modules.push(currentModule)
+        }
+        const match = line.match(/^- name: (.+)$/)
+        currentModule = { name: match![1], items: [] }
+        inItems = false
+        currentItem = null
+      }
+      // Published field
+      else if (line.match(/^  published: (true|false)$/) && currentModule) {
+        const match = line.match(/^  published: (true|false)$/)
+        currentModule.published = match![1] === 'true'
+      }
+      // Items start
+      else if (line.match(/^  items:$/) && currentModule) {
+        inItems = true
+        currentModule.items = []
+      }
+      // Item start
+      else if (line.match(/^  - type: (.+)$/) && currentModule && inItems) {
+        if (currentItem) {
+          currentModule.items!.push(currentItem)
+        }
+        const match = line.match(/^  - type: (.+)$/)
+        currentItem = { type: match![1] }
+      }
+      // Item properties
+      else if (currentItem && inItems) {
+        const pageUrlMatch = line.match(/^    page_url: (.+)$/)
+        const titleMatch = line.match(/^    title: ['"]?(.+?)['"]?$/)
+        const urlMatch = line.match(/^    url: (.+)$/)
+        const contentIdMatch = line.match(/^    content_id: ['"]?(.+?)['"]?$/)
+
+        if (pageUrlMatch) currentItem.page_url = pageUrlMatch[1]
+        if (titleMatch) currentItem.title = titleMatch[1]
+        if (urlMatch) currentItem.url = urlMatch[1]
+        if (contentIdMatch) currentItem.content_id = contentIdMatch[1]
+      }
+    }
+
+    // Don't forget the last module and item
+    if (currentItem && currentModule) {
+      currentModule.items!.push(currentItem)
+    }
+    if (currentModule) {
+      modules.push(currentModule)
+    }
+
+    return modules
+  }
+
+  private findFiles(dir: string, extension: string, excludeDirs: string[] = []): string[] {
+    const files: string[] = []
+
+    if (!fs.existsSync(dir)) {
+      return files
+    }
+
+    const entries = fs.readdirSync(dir, { withFileTypes: true })
+
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name)
+
+      if (entry.isDirectory()) {
+        if (!excludeDirs.includes(entry.name) && !entry.name.startsWith('.')) {
+          files.push(...this.findFiles(fullPath, extension, excludeDirs))
+        }
+      } else if (entry.isFile() && entry.name.endsWith(extension)) {
+        files.push(fullPath)
+      }
+    }
+
+    return files
+  }
+
+  private async getFileSyncStatus(filePath: string, course: CourseInfo): Promise<SyncStatus> {
+    // For now, return 'synced' as placeholder
+    // TODO: Implement actual sync status checking via MCP
+    try {
+      const content = fs.readFileSync(filePath, 'utf8')
+      // Check if file has page_id in frontmatter (indicates it's been synced)
+      if (content.includes('page_id:') || content.includes('quiz_id:')) {
+        // Check if modified since last sync by comparing updated_at
+        const updatedMatch = content.match(/updated_at: ['"]?([^'"\n]+)['"]?/)
+        if (updatedMatch) {
+          const canvasDate = new Date(updatedMatch[1])
+          const fileStats = fs.statSync(filePath)
+          if (fileStats.mtime > canvasDate) {
+            return 'modified'
+          }
+          return 'synced'
+        }
+        return 'synced'
+      }
+      return 'localOnly'
+    } catch (e) {
+      return 'unknown'
+    }
+  }
+
+  // Public methods for managing courses
+
+  addCourse(course: CourseInfo) {
+    // Check if already registered
+    const existing = this.registry.courses.find(c => c.id === course.id)
+    if (existing) {
+      // Update path if different
+      existing.localPath = course.localPath
+      existing.remoteUrl = course.remoteUrl
+    } else {
+      this.registry.courses.push(course)
+    }
+
+    this.saveRegistry()
+    this.watchCourse(course.localPath)
+    this.refresh()
+  }
+
+  removeCourse(courseId: string) {
+    const index = this.registry.courses.findIndex(c => c.id === courseId)
+    if (index >= 0) {
+      const course = this.registry.courses[index]
+      const watcher = this.fileWatchers.get(course.localPath)
+      if (watcher) {
+        watcher.dispose()
+        this.fileWatchers.delete(course.localPath)
+      }
+      this.registry.courses.splice(index, 1)
+      this.saveRegistry()
+      this.refresh()
+    }
+  }
+
+  getCourseByPath(localPath: string): CourseInfo | undefined {
+    return this.registry.courses.find(c => c.localPath === localPath)
+  }
+
+  getCourseById(id: string): CourseInfo | undefined {
+    return this.registry.courses.find(c => c.id === id)
+  }
+
+  getAllCourses(): CourseInfo[] {
+    return [...this.registry.courses]
+  }
+
+  dispose() {
+    for (const watcher of this.fileWatchers.values()) {
+      watcher.dispose()
+    }
+    this.fileWatchers.clear()
+  }
+}


### PR DESCRIPTION
## Summary
Adds a **Rubrics** category under each course in the sidebar tree view, similar to Pages, Quizzes, and Modules.

## Implementation
- New 'Rubrics' category with checklist icon
- Scans `rubrics/*.rubric.yaml` files in each course directory
- Displays assignment name and criteria count: `Essay Rubric (5 criteria)`
- Shows points possible in description: `100 pts`
- Sync status icons: synced (green check) or localOnly (cloud-upload)
- Auto-syncs rubrics from Canvas when expanding empty category
- Click to open YAML file in editor

## Files Changed
- `src/courseTreeProvider.ts` - Added rubric category, item type, parsing logic
- `package.json` - Added context menu items for rubric files

## Test Plan
- [ ] Rubrics category appears in tree view under each course
- [ ] Each rubric shows assignment name and criteria count
- [ ] Sync status icons display correctly
- [ ] Clicking opens the YAML file in editor
- [ ] Auto-sync works when category is empty

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)